### PR TITLE
Add blog section with tagged posts

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -96,3 +96,18 @@ footer {
   }
 }
 
+.main-nav {
+  background: var(--footer-bg);
+  padding: 1rem;
+  display: flex;
+  gap: 1rem;
+}
+
+.main-nav button {
+  background: none;
+  border: none;
+  cursor: pointer;
+  color: inherit;
+  font-size: 1rem;
+}
+

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,125 +1,34 @@
 import { useState } from 'react';
+import Home from './Home';
+import Blog from './Blog';
+import Post from './Post';
 import './App.css';
-import { translations } from './translations';
 
 export default function App() {
-  const [lang, setLang] = useState('pt');
+  const [page, setPage] = useState('home');
+  const [currentPost, setCurrentPost] = useState(null);
 
-  const [dark, setDark] = useState(false);
-  const t = translations[lang];
+  const openPost = (id) => {
+    setCurrentPost(id);
+    setPage('post');
+  };
+
+  let content;
+  if (page === 'home') {
+    content = <Home />;
+  } else if (page === 'blog') {
+    content = <Blog openPost={openPost} />;
+  } else if (page === 'post') {
+    content = <Post id={currentPost} goBack={() => setPage('blog')} />;
+  }
 
   return (
-    <div className={`app ${dark ? 'dark' : ''}`}>
-      <div className="top-bar">
-
-        <select value={lang} onChange={(e) => setLang(e.target.value)}>
-          <option value="pt">PT-BR</option>
-          <option value="en">EN</option>
-        </select>
-
-        <button className="theme-toggle" onClick={() => setDark(!dark)}>
-          {dark ? t.lightMode : t.darkMode}
-        </button>
-
-      </div>
-
-      <header className="header">
-        <h1>{t.title}</h1>
-        <h2>{t.subtitle}</h2>
-
-        <div className="contact">
-          {t.contact.map((line, i) => (
-            <p key={i}>{line}</p>
-          ))}
-        </div>
-        <div className="socials">
-          <a
-            href="https://www.linkedin.com/in/cristiano-koxne-8866511b9/"
-            target="_blank"
-            rel="noopener noreferrer"
-          >
-            <img src="/images/lkd.png" alt="LinkedIn" />
-          </a>
-          <a
-            href="https://github.com/cristianokoxne"
-            target="_blank"
-            rel="noopener noreferrer"
-          >
-            <img src="/images/git.png" alt="GitHub" />
-          </a>
-          <a
-            href="https://www.instagram.com/cristianokoxne/"
-            target="_blank"
-            rel="noopener noreferrer"
-          >
-            <img src="/images/insta.png" alt="Instagram" />
-          </a>
-          <a
-            href="https://twitter.com/cristianokoxne"
-            target="_blank"
-            rel="noopener noreferrer"
-          >
-            <img src="/images/tw.png" alt="Twitter" />
-          </a>
-
-        </div>
-      </header>
-
-      <section>
-
-        <h3>{t.summaryTitle}</h3>
-        <p>{t.summaryText}</p>
-      </section>
-
-      <section>
-        <h3>{t.skillsTitle}</h3>
-        <ul>
-          {t.skillsList.map((skill, i) => (
-            <li key={i}>{skill}</li>
-          ))}
-        </ul>
-      </section>
-
-      <section>
-        <h3>{t.educationTitle}</h3>
-        {t.education.map((ed, i) => (
-          <div key={i} className="education-item">
-            <strong>{ed.period}</strong> – {ed.degree}
-          </div>
-        ))}
-
-      </section>
-
-      <section>
-        <h3>{t.experienceTitle}</h3>
-
-        {t.experience.map((exp, i) => (
-          <div key={i} className="exp-item">
-            <h4>{exp.period}</h4>
-            <p><strong>{exp.role}</strong></p>
-            <ul>
-              {exp.details.map((d, j) => (
-                <li key={j}>{d}</li>
-              ))}
-            </ul>
-          </div>
-        ))}
-      </section>
-
-      <section>
-        <h3>{t.languagesTitle}</h3>
-        <ul>
-          {t.languagesList.map((l, i) => (
-            <li key={i}>{l}</li>
-          ))}
-        </ul>
-
-      </section>
-
-      <footer>
-        <p>{t.footer}</p>
-      </footer>
+    <div>
+      <nav className="main-nav">
+        <button onClick={() => setPage('home')}>Home</button>
+        <button onClick={() => setPage('blog')}>Blog</button>
+      </nav>
+      {content}
     </div>
   );
 }
-

--- a/src/Blog.css
+++ b/src/Blog.css
@@ -1,0 +1,27 @@
+.blog-item {
+  display: flex;
+  cursor: pointer;
+  margin-bottom: 1rem;
+  padding-bottom: 0.5rem;
+  border-bottom: 1px solid #ddd;
+}
+
+.tags {
+  min-width: 120px;
+}
+
+.tag {
+  display: block;
+  background: #ddd;
+  padding: 0.25rem 0.5rem;
+  margin-bottom: 0.25rem;
+  border-radius: 4px;
+}
+
+.summary h3 {
+  margin: 0;
+}
+
+.post .tags {
+  margin: 0.5rem 0;
+}

--- a/src/Blog.jsx
+++ b/src/Blog.jsx
@@ -1,0 +1,22 @@
+import { posts } from './posts';
+import './Blog.css';
+
+export default function Blog({ openPost }) {
+  return (
+    <div className="blog">
+      {posts.map((post) => (
+        <div key={post.id} className="blog-item" onClick={() => openPost(post.id)}>
+          <div className="tags">
+            {post.tags.map((tag) => (
+              <span key={tag} className="tag">{tag}</span>
+            ))}
+          </div>
+          <div className="summary">
+            <h3>{post.title}</h3>
+            <p>{post.summary}</p>
+          </div>
+        </div>
+      ))}
+    </div>
+  );
+}

--- a/src/Home.jsx
+++ b/src/Home.jsx
@@ -1,0 +1,125 @@
+import { useState } from 'react';
+import './App.css';
+import { translations } from './translations';
+
+export default function Home() {
+  const [lang, setLang] = useState('pt');
+
+  const [dark, setDark] = useState(false);
+  const t = translations[lang];
+
+  return (
+    <div className={`app ${dark ? 'dark' : ''}`}>
+      <div className="top-bar">
+
+        <select value={lang} onChange={(e) => setLang(e.target.value)}>
+          <option value="pt">PT-BR</option>
+          <option value="en">EN</option>
+        </select>
+
+        <button className="theme-toggle" onClick={() => setDark(!dark)}>
+          {dark ? t.lightMode : t.darkMode}
+        </button>
+
+      </div>
+
+      <header className="header">
+        <h1>{t.title}</h1>
+        <h2>{t.subtitle}</h2>
+
+        <div className="contact">
+          {t.contact.map((line, i) => (
+            <p key={i}>{line}</p>
+          ))}
+        </div>
+        <div className="socials">
+          <a
+            href="https://www.linkedin.com/in/cristiano-koxne-8866511b9/"
+            target="_blank"
+            rel="noopener noreferrer"
+          >
+            <img src="/images/lkd.png" alt="LinkedIn" />
+          </a>
+          <a
+            href="https://github.com/cristianokoxne"
+            target="_blank"
+            rel="noopener noreferrer"
+          >
+            <img src="/images/git.png" alt="GitHub" />
+          </a>
+          <a
+            href="https://www.instagram.com/cristianokoxne/"
+            target="_blank"
+            rel="noopener noreferrer"
+          >
+            <img src="/images/insta.png" alt="Instagram" />
+          </a>
+          <a
+            href="https://twitter.com/cristianokoxne"
+            target="_blank"
+            rel="noopener noreferrer"
+          >
+            <img src="/images/tw.png" alt="Twitter" />
+          </a>
+
+        </div>
+      </header>
+
+      <section>
+
+        <h3>{t.summaryTitle}</h3>
+        <p>{t.summaryText}</p>
+      </section>
+
+      <section>
+        <h3>{t.skillsTitle}</h3>
+        <ul>
+          {t.skillsList.map((skill, i) => (
+            <li key={i}>{skill}</li>
+          ))}
+        </ul>
+      </section>
+
+      <section>
+        <h3>{t.educationTitle}</h3>
+        {t.education.map((ed, i) => (
+          <div key={i} className="education-item">
+            <strong>{ed.period}</strong> – {ed.degree}
+          </div>
+        ))}
+
+      </section>
+
+      <section>
+        <h3>{t.experienceTitle}</h3>
+
+        {t.experience.map((exp, i) => (
+          <div key={i} className="exp-item">
+            <h4>{exp.period}</h4>
+            <p><strong>{exp.role}</strong></p>
+            <ul>
+              {exp.details.map((d, j) => (
+                <li key={j}>{d}</li>
+              ))}
+            </ul>
+          </div>
+        ))}
+      </section>
+
+      <section>
+        <h3>{t.languagesTitle}</h3>
+        <ul>
+          {t.languagesList.map((l, i) => (
+            <li key={i}>{l}</li>
+          ))}
+        </ul>
+
+      </section>
+
+      <footer>
+        <p>{t.footer}</p>
+      </footer>
+    </div>
+  );
+}
+

--- a/src/Post.jsx
+++ b/src/Post.jsx
@@ -1,0 +1,20 @@
+import { posts } from './posts';
+import './Blog.css';
+
+export default function Post({ id, goBack }) {
+  const post = posts.find((p) => p.id === id);
+  if (!post) return null;
+
+  return (
+    <div className="post">
+      <button onClick={goBack}>Voltar</button>
+      <h2>{post.title}</h2>
+      <div className="tags">
+        {post.tags.map((tag) => (
+          <span key={tag} className="tag">{tag}</span>
+        ))}
+      </div>
+      <p>{post.content}</p>
+    </div>
+  );
+}

--- a/src/posts.js
+++ b/src/posts.js
@@ -1,0 +1,16 @@
+export const posts = [
+  {
+    id: 'hello-world',
+    title: 'Hello World',
+    summary: 'Introdução ao meu blog.',
+    content: 'Bem-vindo ao meu novo blog! Aqui irei compartilhar ideias e experiências.',
+    tags: ['Introdução', 'Pessoal']
+  },
+  {
+    id: 'second-post',
+    title: 'Segundo Post',
+    summary: 'Um breve resumo do segundo artigo.',
+    content: 'Este é o conteúdo completo do segundo post. Em breve teremos mais novidades.',
+    tags: ['Tech', 'Novidades']
+  }
+];


### PR DESCRIPTION
## Summary
- add blog page listing posts with tags and summaries
- add simple navigation between home, blog, and individual posts
- style navigation bar and tags

## Testing
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a76a5d2a788326bff778ffb53677fa